### PR TITLE
Feat : 봉사활동 신청 승인 기능 추가

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
@@ -1,0 +1,50 @@
+package com.sbsj.dreamwing.admin.controller;
+
+import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+import com.sbsj.dreamwing.admin.service.AdminService;
+import com.sbsj.dreamwing.util.ApiResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 컨트롤러
+ * @author 정은지
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.28   정은지        최초 생성
+ * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * </pre>
+ */
+@RestController
+@RequestMapping(value="/admin", produces=MediaType.APPLICATION_JSON_VALUE)
+@Slf4j
+@AllArgsConstructor
+public class AdminController {
+
+    private final AdminService service;
+
+    /**
+     *
+     * @param request
+     * @return
+     * @throws Exception
+     */
+    @PatchMapping("/volunteer/approve")
+    public ResponseEntity<ApiResponse<Void>> approveVolunteerRequest(
+            @RequestBody UpdateVolunteerStatusRequestDTO request) throws Exception {
+        return service.approveVolunteerRequest(request) ?
+                    ResponseEntity.ok(ApiResponse.success(HttpStatus.OK)) :
+                    ResponseEntity.badRequest().body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사활동 요청 승인 실패"));
+    }
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
@@ -35,7 +35,7 @@ public class AdminController {
     private final AdminService service;
 
     /**
-     *
+     * 사용자 봉사활동 신청 승인
      * @param request
      * @return
      * @throws Exception

--- a/src/main/java/com/sbsj/dreamwing/admin/dto/UpdateVolunteerStatusRequestDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/dto/UpdateVolunteerStatusRequestDTO.java
@@ -1,0 +1,21 @@
+package com.sbsj.dreamwing.admin.dto;
+
+import lombok.Data;
+
+/**
+ * 봉사활동 승인 요청 DTO
+ * @author 정은지
+ * @since 2024.07.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.26  	정은지        최초 생성
+ * </pre>
+ */
+@Data
+public class UpdateVolunteerStatusRequestDTO {
+    private long volunteerId;
+    private long userId;
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/mapper/AdminMapper.java
@@ -1,0 +1,22 @@
+package com.sbsj.dreamwing.admin.mapper;
+
+import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 관리자 매퍼 인터페이스
+ * @author 정은지
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.28  	정은지        최초 생성
+ * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * </pre>
+ */
+@Mapper
+public interface AdminMapper {
+    public int updateVolunteerStatus(UpdateVolunteerStatusRequestDTO request);
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/service/AdminService.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/service/AdminService.java
@@ -1,0 +1,22 @@
+package com.sbsj.dreamwing.admin.service;
+
+
+import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+
+/**
+ * 관리자 서비스 인터페이스
+ * @author 정은지
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.28  	정은지        최초 생성
+ * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * </pre>
+ */
+public interface AdminService {
+
+    boolean approveVolunteerRequest(UpdateVolunteerStatusRequestDTO request) throws Exception;
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/service/AdminServiceImpl.java
@@ -1,0 +1,33 @@
+package com.sbsj.dreamwing.admin.service;
+
+import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+import com.sbsj.dreamwing.admin.mapper.AdminMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 관리자 서비스 구현체
+ * @author 정은지
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.28  	정은지        최초 생성
+ * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * </pre>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    private final AdminMapper mapper;
+
+    @Override
+    public boolean approveVolunteerRequest(UpdateVolunteerStatusRequestDTO request) {
+        return mapper.updateVolunteerStatus(request) == 1;
+    }
+}

--- a/src/main/resources/com/sbsj/dreamwing/admin/mapper/AdminMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/admin/mapper/AdminMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!--
+* 관리자 Mybatis 매퍼
+* @author 정은지
+* @since 2024.07.28
+* @version 1.0
+*
+* <pre>
+* 수정일        	수정자        수정내용
+* ==========  =========    =========
+* 2024.07.28   정은지         최초 생성
+* 2024.07.28   정은지         봉사활동 승인 기능 추가
+*
+* </pre>
+-->
+<mapper namespace="com.sbsj.dreamwing.admin.mapper.AdminMapper">
+    <update id="updateVolunteerStatus">
+        UPDATE USER_VOLUNTEER
+        SET    STATUS = 1
+        WHERE  VOLUNTEER_ID = #{volunteerId}
+               AND USER_ID = #{userId}
+    </update>
+
+</mapper>

--- a/src/test/java/com/sbsj/dreamwing/admin/mapper/AdminMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/admin/mapper/AdminMapperTests.java
@@ -1,0 +1,54 @@
+package com.sbsj.dreamwing.admin.mapper;
+
+import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+import com.sbsj.dreamwing.mission.domain.QuizVO;
+import com.sbsj.dreamwing.mission.dto.AwardPointsRequestDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 관리자 매퍼 테스트 클래스
+ * @author 정은지
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.28  	정은지        최초 생성
+ * 2024.07.28   정은지        봉사활동 신청 승인 테스트 추가
+ * </pre>
+ */
+
+@Slf4j
+@SpringBootTest
+public class AdminMapperTests {
+
+    @Autowired
+    private AdminMapper mapper;
+
+    @Test
+    @DisplayName("봉사활동 신청 승인 매퍼 테스트")
+    public void testUpdateVolunteerStatus() {
+
+        // given
+        UpdateVolunteerStatusRequestDTO dto = new UpdateVolunteerStatusRequestDTO();
+        dto.setVolunteerId(2L);
+        dto.setUserId(1L);
+
+        // when
+        int success = mapper.updateVolunteerStatus(dto);
+
+        // then
+        Assertions.assertEquals(success, 1);
+    }
+}

--- a/src/test/java/com/sbsj/dreamwing/admin/service/AdminServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/admin/service/AdminServiceTests.java
@@ -1,0 +1,53 @@
+package com.sbsj.dreamwing.admin.service;
+
+import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+import com.sbsj.dreamwing.mission.domain.QuizVO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * 관리자 서비스 테스트
+ * @author 정은지
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.28  	정은지        최초 생성
+ * 2024.07.28   정은지        봉사활동 신청 승인 테스트 추가
+ * </pre>
+ */
+
+@Slf4j
+@SpringBootTest
+public class AdminServiceTests {
+
+    @Autowired
+    private AdminService service;
+
+    @Test
+    @DisplayName("봉사활동 신청 승인 서비스 테스트")
+    public void testApproveVolunteerRequest() throws Exception {
+        // given
+        UpdateVolunteerStatusRequestDTO dto = new UpdateVolunteerStatusRequestDTO();
+        dto.setVolunteerId(3L);
+        dto.setUserId(1L);
+
+        // when
+        boolean success = service.approveVolunteerRequest(dto);
+
+        // then
+        assertTrue(success, "봉사활동 신청 승인 실패");
+    }
+}


### PR DESCRIPTION
# 💡 PR 요약
사용자 봉사활동 신청 검토 후 관리자 승인 기능

## ⭐️ 관련 이슈
- closes : #20 

## ⭐️ 작업한 내용
- USER_VOLUNTEER 테이블 status 컬럼 값 0(대기) -> 1(확정)로 변경
- 단위 테스트 진행

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
