### PR TITLE
Feat : 후원 하기 요청 API 작성

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/support/controller/SupportController.java
+++ b/src/main/java/com/sbsj/dreamwing/support/controller/SupportController.java
@@ -5,6 +5,7 @@ import com.sbsj.dreamwing.mission.dto.AwardPointsRequestDTO;
 import com.sbsj.dreamwing.mission.service.MissionService;
 import com.sbsj.dreamwing.support.dto.GetSupportListResponseDTO;
 import com.sbsj.dreamwing.support.dto.GetTotalSupportResponseDTO;
+import com.sbsj.dreamwing.support.dto.PostSupportGiveRequestDTO;
 import com.sbsj.dreamwing.support.service.SupportService;
 import com.sbsj.dreamwing.util.ApiResponse;
 import lombok.AllArgsConstructor;
@@ -73,4 +74,23 @@ public class SupportController {
         List<GetSupportListResponseDTO> response = service.getAllSupportList();
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, response));
     }
+
+    /**
+     * 포인트 기부
+     * @param request
+     * @return
+     * @throws Exception
+     */
+    @PostMapping("/give")
+    public ResponseEntity<ApiResponse<Void>> SupportGivePoints(@RequestBody PostSupportGiveRequestDTO request) throws Exception {
+        boolean success = service.SupportGivePoints(request);
+        if (success) {
+            return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "포인트가 부족합니다."));
+        }
+    }
+
+
+
 }

--- a/src/main/java/com/sbsj/dreamwing/support/dto/PostSupportGiveRequestDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/support/dto/PostSupportGiveRequestDTO.java
@@ -1,0 +1,24 @@
+package com.sbsj.dreamwing.support.dto;
+
+import lombok.Data;
+/**
+ * 후원 요청 DTO
+ * @author 임재성
+ * @since 2024.07.28
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.29  	임재성        최초 생성
+ * </pre>
+ */
+
+
+
+@Data
+public class PostSupportGiveRequestDTO {
+    private long userId; // 사용자의 ID
+    private long supportId; // 지원 항목의 ID
+    private int point; // 기부할 포인트
+}

--- a/src/main/java/com/sbsj/dreamwing/support/mapper/SupportMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/support/mapper/SupportMapper.java
@@ -3,6 +3,7 @@ package com.sbsj.dreamwing.support.mapper;
 import com.sbsj.dreamwing.support.dto.GetSupportListResponseDTO;
 import com.sbsj.dreamwing.support.dto.GetTotalSupportResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -25,5 +26,16 @@ public interface SupportMapper {
     public GetTotalSupportResponseDTO selectTotalSupport();
     public List<GetSupportListResponseDTO> selectSupportList();
     public List<GetSupportListResponseDTO> selectAllSupportList();
+    // 사용자 포인트 가져오기
+    int getUserPoints(@Param("userId") long userId);
+
+    // 사용자 포인트 업데이트
+    int updateUserPoints(@Param("userId") long userId, @Param("newPoints") int point);
+
+    //후원 항목 포인트 가져오기
+    int getSupportPoints(long supportId);
+
+    // 후원 항목 포인트 업데이트
+    int updateSupportPoints(@Param("supportId") long supportId, @Param("pointsToAdd") int pointsToAdd);
 
 }

--- a/src/main/java/com/sbsj/dreamwing/support/service/SupportService.java
+++ b/src/main/java/com/sbsj/dreamwing/support/service/SupportService.java
@@ -3,6 +3,7 @@ package com.sbsj.dreamwing.support.service;
 
 import com.sbsj.dreamwing.support.dto.GetSupportListResponseDTO;
 import com.sbsj.dreamwing.support.dto.GetTotalSupportResponseDTO;
+import com.sbsj.dreamwing.support.dto.PostSupportGiveRequestDTO;
 
 import java.util.List;
 
@@ -24,4 +25,6 @@ public interface SupportService {
     GetTotalSupportResponseDTO getTotalSupport() throws Exception;
     List<GetSupportListResponseDTO> getSupportList() throws Exception;
     List<GetSupportListResponseDTO> getAllSupportList() throws Exception;
+    boolean SupportGivePoints(PostSupportGiveRequestDTO request) throws Exception;
+
 }

--- a/src/main/java/com/sbsj/dreamwing/support/service/SupportServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/support/service/SupportServiceImpl.java
@@ -2,10 +2,12 @@ package com.sbsj.dreamwing.support.service;
 
 import com.sbsj.dreamwing.support.dto.GetSupportListResponseDTO;
 import com.sbsj.dreamwing.support.dto.GetTotalSupportResponseDTO;
+import com.sbsj.dreamwing.support.dto.PostSupportGiveRequestDTO;
 import com.sbsj.dreamwing.support.mapper.SupportMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -44,4 +46,24 @@ public class SupportServiceImpl implements SupportService {
     public List<GetSupportListResponseDTO> getAllSupportList() throws Exception {
         return mapper.selectAllSupportList();
     }
+
+    @Transactional
+    @Override
+    public boolean SupportGivePoints(PostSupportGiveRequestDTO request) throws Exception {
+        // 사용자의 보유 포인트를 가져와서 확인 (보유 포인트 확인 로직 필요)
+        int userPoints = mapper.getUserPoints(request.getUserId());
+        if (userPoints < request.getPoint()) {
+            return false; // 포인트가 부족하면 false 반환
+        }
+
+        // 사용자의 포인트 차감
+        mapper.updateUserPoints(request.getUserId(), request.getPoint());
+
+        // 기부 내역 업데이트
+        mapper.updateSupportPoints(request.getSupportId(), request.getPoint());
+
+        return true;
+    }
+
+
 }

--- a/src/main/resources/com/sbsj/dreamwing/support/mapper/SupportMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/support/mapper/SupportMapper.xml
@@ -13,6 +13,7 @@
 * 2024.07.28   정은지         최초 생성
 * 2024.07.28   정은지         후원 총 횟수,금액 조회/후원 리스트 조회 추가
 * 2024.07.28   임재성         모든 후원 리스트 조회 테스트 추가
+* 2024.07.29   임재성         후원 하기 요청 기능 추가
 * </pre>
 -->
 <mapper namespace="com.sbsj.dreamwing.support.mapper.SupportMapper">
@@ -46,5 +47,32 @@
         FROM SUPPORT
         ORDER BY DDAY
     </select>
+
+    <!-- 사용자 포인트 가져오기 -->
+    <select id="getUserPoints" parameterType="long" resultType="int">
+        SELECT TOTAL_POINT
+        FROM   USER_INFO
+        WHERE  USER_ID = #{userId}
+    </select>
+
+    <!-- 사용자 포인트 업데이트 -->
+    <update id="updateUserPoints">
+        UPDATE USER_INFO
+        SET    TOTAL_POINT = TOTAL_POINT - #{newPoints}
+        WHERE  USER_ID = #{userId}
+    </update>
+
+    <select id="getSupportPoints" resultType="int" parameterType="long">
+        SELECT CURRENT_POINT
+        FROM   SUPPORT
+        WHERE  SUPPORT_ID = #{supportId}
+    </select>
+
+    <!-- 지원 항목 포인트 업데이트 -->
+    <update id="updateSupportPoints">
+        UPDATE SUPPORT
+        SET    CURRENT_POINT = CURRENT_POINT + #{pointsToAdd}
+        WHERE  SUPPORT_ID = #{supportId}
+    </update>
 
 </mapper>

--- a/src/test/java/com/sbsj/dreamwing/support/mapper/SupportMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/support/mapper/SupportMapperTests.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        후원 총 횟수,금액 조회/후원 리스트 조회 테스트 추가
  * 2024.07.28   임재성        모든 후원 리스트 조회 테스트 추가
+ * 2024.07.29   임재성        후원 하기 요청 테스트 추가
  * </pre>
  */
 
@@ -76,4 +77,40 @@ public class SupportMapperTests {
         log.info(dto.toString());
         Assertions.assertNotNull(dto, "조회에 실패하였습니다.");
     }
+
+
+
+    ////후원하기////
+
+    @Test
+    void testGetUserPoints() {
+        long userId = 1L; // 존재하는 사용자 ID로 대체
+        int point = mapper.getUserPoints(userId);
+        log.info("User Points: {}", point);
+        assertThat(point).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void testUpdateUserPoints() {
+        long userId = 1L; // 존재하는 사용자 ID로 대체
+        int newPoints = 500;
+        int result = mapper.updateUserPoints(userId, newPoints);
+        int updatedPoints = mapper.getUserPoints(userId);
+        log.info("Updated User Points: {}", updatedPoints);
+        assertThat(result).isEqualTo(1);
+    }
+
+    @Test
+    void testUpdateSupportPoints() {
+        long supportId = 6L; // 존재하는 지원 항목 ID로 대체
+        int currentPoint = mapper.getSupportPoints(supportId);
+        int pointsToAdd = 200;
+        mapper.updateSupportPoints(supportId, pointsToAdd);
+        int updatedPoints = mapper.getSupportPoints(supportId);
+        log.info("Updated Support Points: {}", updatedPoints);
+        assertThat(updatedPoints).isEqualTo(currentPoint + pointsToAdd);
+    }
+
+
+
 }

--- a/src/test/java/com/sbsj/dreamwing/support/service/SupportServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/support/service/SupportServiceTests.java
@@ -3,12 +3,15 @@ package com.sbsj.dreamwing.support.service;
 
 import com.sbsj.dreamwing.support.dto.GetSupportListResponseDTO;
 import com.sbsj.dreamwing.support.dto.GetTotalSupportResponseDTO;
+import com.sbsj.dreamwing.support.dto.PostSupportGiveRequestDTO;
+import com.sbsj.dreamwing.support.mapper.SupportMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -32,6 +35,8 @@ public class SupportServiceTests {
 
     @Autowired
     private SupportService service;
+    @Autowired
+    private SupportMapper mapper; // 매퍼 주입
 
     @Test
     @DisplayName("총 후원 금액 및 횟수 조회 서비스 테스트")
@@ -71,4 +76,86 @@ public class SupportServiceTests {
         log.info(String.valueOf(response));
         Assertions.assertNotNull(response, "조회에 실패하였습니다.");
     }
+
+
+    @Test
+    @DisplayName("사용자 후원 기부 테스트")
+    public void testSupportGivePoints() throws Exception {
+        // given
+        PostSupportGiveRequestDTO dto = new PostSupportGiveRequestDTO();
+        dto.setUserId(1L);
+        dto.setSupportId(6L);
+        dto.setPoint(200);
+
+        // 기부 전 사용자와 후원 항목의 초기 포인트 가져오기
+        int initialUserPoints = mapper.getUserPoints(dto.getUserId());
+        int initialSupportPoints = mapper.getSupportPoints(dto.getSupportId());
+
+        // when
+        boolean result = service.SupportGivePoints(dto);
+
+        // then
+        Assertions.assertTrue(result, "후원 기부에 실패하였습니다.");
+
+        // 기부 후 사용자와 후원 항목의 포인트 가져오기
+        int updatedUserPoints = mapper.getUserPoints(dto.getUserId());
+        int updatedSupportPoints = mapper.getSupportPoints(dto.getSupportId());
+
+        log.info("Initial User Points: {}", initialUserPoints);
+        log.info("Updated User Points: {}", updatedUserPoints);
+        log.info("Initial Support Points: {}", initialSupportPoints);
+        log.info("Updated Support Points: {}", updatedSupportPoints);
+
+        Assertions.assertEquals(initialUserPoints - dto.getPoint(), updatedUserPoints, "사용자의 포인트 업데이트에 실패하였습니다.");
+        Assertions.assertEquals(initialSupportPoints + dto.getPoint(), updatedSupportPoints, "후원 항목의 포인트 업데이트에 실패하였습니다.");
+    }
+
+    @Test
+    @DisplayName("사용자 후원 기부 - 포인트 부족 테스트")
+    @Transactional
+    public void testSupportGivePoints_NotEnoughPoints() throws Exception {
+        // given
+        PostSupportGiveRequestDTO dto = new PostSupportGiveRequestDTO();
+        dto.setUserId(1L);
+        dto.setSupportId(6L);
+        dto.setPoint(700); // 포인트 부족하게 설정
+
+        // 기부 전 사용자와 후원 항목의 초기 포인트 가져오기
+        int initialUserPoints = mapper.getUserPoints(dto.getUserId());
+        int initialSupportPoints = mapper.getSupportPoints(dto.getSupportId());
+
+        // when
+        boolean result = service.SupportGivePoints(dto);
+
+        // then
+        Assertions.assertFalse(result, "포인트가 부족한 경우에도 후원 기부가 성공하였습니다.");
+
+        // 포인트 부족으로 인해 업데이트가 발생하지 않아야 합니다.
+        int updatedUserPoints = mapper.getUserPoints(dto.getUserId());
+        int updatedSupportPoints = mapper.getSupportPoints(dto.getSupportId());
+
+        log.info("Initial User Points: {}", initialUserPoints);
+        log.info("Updated User Points: {}", updatedUserPoints);
+        log.info("Initial Support Points: {}", initialSupportPoints);
+        log.info("Updated Support Points: {}", updatedSupportPoints);
+
+        Assertions.assertEquals(initialUserPoints, updatedUserPoints, "포인트가 부족한 경우 사용자의 포인트가 잘못 업데이트되었습니다.");
+        Assertions.assertEquals(initialSupportPoints, updatedSupportPoints, "포인트가 부족한 경우 후원 항목의 포인트가 잘못 업데이트되었습니다.");
+    }
 }
+
+    // 필요한 경우 추가적인 메서드를 여기에 작성하세요.}
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION


# 💡 PR 요약
후원하기 요청 API 작성하여 PR 합니다.

## ⭐️ 관련 이슈
- closes : #24 
- 
## ⭐️ 작업한 내용
- 사용자의 총 보유 포인트에서 후원한 포인트만큼 빼서 저장하기
- 후원한 포인트만큼 후원항목의 현재 포인트에 더해서 저장하기

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
