### PR TITLE
Feat : 봉사 & 멘토링 관리자 인증 후 포인트 부여 기능 추가

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
@@ -1,17 +1,18 @@
 package com.sbsj.dreamwing.admin.controller;
 
+import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.admin.service.AdminService;
+import com.sbsj.dreamwing.mission.dto.AwardPointsRequestDTO;
+import com.sbsj.dreamwing.mission.service.MissionService;
 import com.sbsj.dreamwing.util.ApiResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 관리자 컨트롤러
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
  * ----------  --------    ---------------------------
  * 2024.07.28   정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * 2024.07.29   정은지        봉사활동 인증 후 포인트 부여 기능 추가
  * </pre>
  */
 @RestController
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminController {
 
     private final AdminService service;
+    private final MissionService missionService;
 
     /**
      * 사용자 봉사활동 신청 승인
@@ -46,5 +49,19 @@ public class AdminController {
         return service.approveVolunteerRequest(request) ?
                     ResponseEntity.ok(ApiResponse.success(HttpStatus.OK)) :
                     ResponseEntity.badRequest().body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사활동 요청 승인 실패"));
+    }
+
+    /**
+     * 봉사활동 포인트 부여
+     * @param request
+     * @return
+     * @throws Exception
+     */
+    @PostMapping("/volunteer/point")
+    public ResponseEntity<ApiResponse<Void>> awardVolunteerPoints(
+            @RequestBody AwardVolunteerPointsRequestDTO request) throws Exception {
+        return service.awardVolunteerPoints(request) ?
+                ResponseEntity.ok(ApiResponse.success(HttpStatus.OK)) :
+                ResponseEntity.badRequest().body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사활동 인증 포인트 부여 실패"));
     }
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/domain/UserVolunteerVO.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/domain/UserVolunteerVO.java
@@ -1,0 +1,24 @@
+package com.sbsj.dreamwing.admin.domain;
+
+import lombok.Data;
+
+/**
+ * 사용자 봉사활동 VO
+ * @author 정은지
+ * @since 2024.07.29
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        	수정자        수정내용
+ * ----------  --------    ---------------------------
+ * 2024.07.29  	정은지        최초 생성
+ * </pre>
+ */
+@Data
+public class UserVolunteerVO {
+    private long volunteerId;
+    private long userId;
+    private int status;
+    private int verified;
+    private String imageUrl;
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/dto/AwardVolunteerPointsRequestDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/dto/AwardVolunteerPointsRequestDTO.java
@@ -1,11 +1,9 @@
 package com.sbsj.dreamwing.admin.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 /**
- * 봉사활동 승인 요청 DTO
+ * 봉사활동 포인트 부여 요청 DTO
  * @author 정은지
  * @since 2024.07.26
  * @version 1.0
@@ -17,9 +15,10 @@ import lombok.NoArgsConstructor;
  * </pre>
  */
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class UpdateVolunteerStatusRequestDTO {
+public class AwardVolunteerPointsRequestDTO {
     private long volunteerId;
     private long userId;
+    private int activityType;
+    private String activityTitle;
+    private int point;
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/mapper/AdminMapper.java
@@ -14,9 +14,11 @@ import org.apache.ibatis.annotations.Mapper;
  * ----------  --------    ---------------------------
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * 2024.07.29   정은지        봉사활동 인증 기능 추가
  * </pre>
  */
 @Mapper
 public interface AdminMapper {
     public int updateVolunteerStatus(UpdateVolunteerStatusRequestDTO request);
+    public int updateVolunteerVerified(UpdateVolunteerStatusRequestDTO request);
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/service/AdminService.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/service/AdminService.java
@@ -1,6 +1,7 @@
 package com.sbsj.dreamwing.admin.service;
 
 
+import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 
 /**
@@ -14,9 +15,10 @@ import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
  * ----------  --------    ---------------------------
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * 2024.07.29   정은지        봉사활동 인증 후 포인트 부여 기능 추가
  * </pre>
  */
 public interface AdminService {
-
     boolean approveVolunteerRequest(UpdateVolunteerStatusRequestDTO request) throws Exception;
+    boolean awardVolunteerPoints(AwardVolunteerPointsRequestDTO request) throws Exception;
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/service/AdminServiceImpl.java
@@ -1,10 +1,14 @@
 package com.sbsj.dreamwing.admin.service;
 
+import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.admin.mapper.AdminMapper;
+import com.sbsj.dreamwing.mission.dto.AwardPointsRequestDTO;
+import com.sbsj.dreamwing.mission.mapper.MissionMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 관리자 서비스 구현체
@@ -17,6 +21,7 @@ import org.springframework.stereotype.Service;
  * ----------  --------    ---------------------------
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
+ * 2024.07.29   정은지        봉사활동 인증 후 포인트 부여 기능 추가
  * </pre>
  */
 @Slf4j
@@ -25,9 +30,26 @@ import org.springframework.stereotype.Service;
 public class AdminServiceImpl implements AdminService {
 
     private final AdminMapper mapper;
+    private final MissionMapper missionMapper;
 
     @Override
     public boolean approveVolunteerRequest(UpdateVolunteerStatusRequestDTO request) {
         return mapper.updateVolunteerStatus(request) == 1;
+    }
+
+    @Transactional
+    @Override
+    public boolean awardVolunteerPoints(AwardVolunteerPointsRequestDTO request) throws Exception {
+        try {
+            mapper.updateVolunteerVerified(new UpdateVolunteerStatusRequestDTO(
+                    request.getVolunteerId(), request.getUserId()));
+
+            missionMapper.callAwardPointsProcedure(new AwardPointsRequestDTO(
+                    request.getUserId(), request.getActivityType(), request.getActivityTitle(), request.getPoint()));
+            return true;
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return false;
+        }
     }
 }

--- a/src/main/java/com/sbsj/dreamwing/mission/dto/AwardPointsRequestDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/mission/dto/AwardPointsRequestDTO.java
@@ -1,6 +1,8 @@
 package com.sbsj.dreamwing.mission.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * 포인트 부여 요청 DTO
@@ -16,6 +18,8 @@ import lombok.Data;
  */
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class AwardPointsRequestDTO {
     private long userId;
     private int activityType;

--- a/src/main/resources/com/sbsj/dreamwing/admin/mapper/AdminMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/admin/mapper/AdminMapper.xml
@@ -12,6 +12,7 @@
 * ==========  =========    =========
 * 2024.07.28   정은지         최초 생성
 * 2024.07.28   정은지         봉사활동 승인 기능 추가
+* 2024.07.29   정은지         봉사활동 인증 기능 추가
 *
 * </pre>
 -->
@@ -23,4 +24,10 @@
                AND USER_ID = #{userId}
     </update>
 
+    <update id="updateVolunteerVerified">
+        UPDATE USER_VOLUNTEER
+        SET    VERIFIED = 1
+        WHERE  VOLUNTEER_ID = #{volunteerId}
+               AND USER_ID = #{userId}
+    </update>
 </mapper>

--- a/src/test/java/com/sbsj/dreamwing/admin/mapper/AdminMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/admin/mapper/AdminMapperTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * ----------  --------    ---------------------------
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 신청 승인 테스트 추가
+ * 2024.07.29   정은지        봉사활동 인증 테스트 추가
  * </pre>
  */
 
@@ -47,6 +48,22 @@ public class AdminMapperTests {
 
         // when
         int success = mapper.updateVolunteerStatus(dto);
+
+        // then
+        Assertions.assertEquals(success, 1);
+    }
+
+    @Test
+    @DisplayName("봉사활동 인증 매퍼 테스트")
+    public void testUpdateVolunteerVerified() {
+
+        // given
+        UpdateVolunteerStatusRequestDTO dto = new UpdateVolunteerStatusRequestDTO();
+        dto.setVolunteerId(2L);
+        dto.setUserId(1L);
+
+        // when
+        int success = mapper.updateVolunteerVerified(dto);
 
         // then
         Assertions.assertEquals(success, 1);

--- a/src/test/java/com/sbsj/dreamwing/admin/service/AdminServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/admin/service/AdminServiceTests.java
@@ -1,8 +1,10 @@
 package com.sbsj.dreamwing.admin.service;
 
+import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.mission.domain.QuizVO;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * ----------  --------    ---------------------------
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 신청 승인 테스트 추가
+ * 2024.07.29   정은지        봉사활동 인증 테스트 추가
  * </pre>
  */
 
@@ -49,5 +52,23 @@ public class AdminServiceTests {
 
         // then
         assertTrue(success, "봉사활동 신청 승인 실패");
+    }
+
+    @Test
+    @DisplayName("봉사활동 인증 포인트 부여 서비스 테스트")
+    public void testVerifyVolunteerRequest() throws Exception {
+        // given
+        AwardVolunteerPointsRequestDTO dto = new AwardVolunteerPointsRequestDTO();
+        dto.setVolunteerId(3L);
+        dto.setUserId(1L);
+        dto.setActivityType(1);
+        dto.setActivityTitle("봉사활동");
+        dto.setPoint(5000);
+
+        // when
+        boolean success = service.awardVolunteerPoints(dto);
+
+        // then
+        assertTrue(success, "봉사활동 인증 실패");
     }
 }


### PR DESCRIPTION
# 💡 PR 요약
봉사 & 멘토링 관리자 인증 후 포인트 부여 기능 추가

## ⭐️ 관련 이슈
- closes : #27 

## ⭐️ 작업한 내용
- USER_VOLUNTEER vo 생성
- USER_VOLUNTEER 테이블 VERIFIED 컬럼 0(미인증) -> 1(인증완료) 변경 후 포인트 부여

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 