### PR TITLE
Feat : 관리자 페이지 내 봉사 & 멘토링 모집 공고 글 생성/수정/삭제/조회 API 작성

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/controller/AdminController.java
@@ -1,11 +1,15 @@
 package com.sbsj.dreamwing.admin.controller;
 
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO;
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO;
 import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.admin.service.AdminService;
 import com.sbsj.dreamwing.mission.dto.AwardPointsRequestDTO;
 import com.sbsj.dreamwing.mission.service.MissionService;
 import com.sbsj.dreamwing.util.ApiResponse;
+import com.sbsj.dreamwing.volunteer.dto.VolunteerListDTO;
+import com.sbsj.dreamwing.volunteer.service.VolunteerService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -13,6 +17,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 관리자 컨트롤러
@@ -26,6 +32,8 @@ import org.springframework.web.bind.annotation.*;
  * 2024.07.28   정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
  * 2024.07.29   정은지        봉사활동 인증 후 포인트 부여 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 조회 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 생성/수정/삭제 기능 추가
  * </pre>
  */
 @RestController
@@ -36,12 +44,13 @@ public class AdminController {
 
     private final AdminService service;
     private final MissionService missionService;
+    private final VolunteerService volunteerService;
 
     /**
      * 사용자 봉사활동 신청 승인
      * @param request
      * @return
-     * @throws Exception
+     * @throws Exception    
      */
     @PatchMapping("/volunteer/approve")
     public ResponseEntity<ApiResponse<Void>> approveVolunteerRequest(
@@ -64,4 +73,64 @@ public class AdminController {
                 ResponseEntity.ok(ApiResponse.success(HttpStatus.OK)) :
                 ResponseEntity.badRequest().body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사활동 인증 포인트 부여 실패"));
     }
+
+
+    /**
+     * 봉사 공고 생성
+     * @param request
+     * @return
+     */
+    @PostMapping("/volunteer/create")
+    public ResponseEntity<ApiResponse<Void>> createVolunteer(
+            @RequestBody AdminVolunteerRequestDTO request) {
+        int result = service.createVolunteer(request);
+        if (result > 0) {
+            return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(HttpStatus.CREATED));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사 공고 생성에 실패했습니다."));
+        }
+    }
+
+    /**
+     * 봉사 공고 수정
+     * @param request
+     * @return
+     */
+    @PutMapping("/volunteer/update")
+    public ResponseEntity<ApiResponse<Void>> updateVolunteer(
+            @RequestBody AdminVolunteerRequestDTO request) {
+        int result = service.updateVolunteer(request);
+        if (result > 0) {
+            return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사 공고 수정에 실패했습니다."));
+        }
+    }
+
+    /**
+     * 봉사 공고 삭제
+     * @param volunteerId
+     * @return
+     */
+    @DeleteMapping("/volunteer/{volunteerId}")
+    public ResponseEntity<ApiResponse<Void>> deleteVolunteer(
+            @PathVariable long volunteerId) {
+        int result = service.deleteVolunteer(volunteerId);
+        if (result > 0) {
+            return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(HttpStatus.BAD_REQUEST, "봉사 공고 삭제에 실패했습니다."));
+        }
+    }
+
+    /**
+     * 봉사 공고 목록 조회
+     * @return
+     */
+    @GetMapping("/volunteer/list")
+    public ResponseEntity<ApiResponse<List<AdminVolunteerResponseDTO>>> getVolunteerList() {
+        List<AdminVolunteerResponseDTO> response = service.getVolunteerList();
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, response));
+    }
+
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/dto/AdminVolunteerRequestDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/dto/AdminVolunteerRequestDTO.java
@@ -1,0 +1,36 @@
+package com.sbsj.dreamwing.admin.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+@Data
+public class AdminVolunteerRequestDTO {
+    private long volunteerId;       // 봉사 ID (수정 시 필요)
+    private String title;           // 봉사 제목
+    private String content;         // 봉사 내용
+    private int type;               // 봉사 또는 멘토링
+    private int category;           // 카테고리
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startDate;    // 봉사 시작일
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endDate;      // 봉사 종료일
+
+    private String address;         // 봉사 주소
+    private int totalCount;         // 모집 인원 수
+    private int status;             // 봉사 상태
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime recruitStartDate; // 모집 시작일
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime recruitEndDate;   // 모집 종료일
+
+    private String imageUrl;        // 이미지 URL
+    private String latitude;        // 위도
+    private String longitude;       // 경도
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/dto/AdminVolunteerResponseDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/dto/AdminVolunteerResponseDTO.java
@@ -1,0 +1,11 @@
+package com.sbsj.dreamwing.admin.dto;
+
+import lombok.Data;
+
+@Data
+public class AdminVolunteerResponseDTO {
+    private long volunteerId;
+    private String title;                         // 봉사 or 멘토링 제목
+    private int type;                             // 봉사 or 멘토링
+    private int currentPerson;                    // 현재 인원 수 (실제 컬럼이 아니며 쿼리로 계산)
+}

--- a/src/main/java/com/sbsj/dreamwing/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/mapper/AdminMapper.java
@@ -1,7 +1,11 @@
 package com.sbsj.dreamwing.admin.mapper;
 
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO;
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 /**
  * 관리자 매퍼 인터페이스
@@ -15,10 +19,17 @@ import org.apache.ibatis.annotations.Mapper;
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
  * 2024.07.29   정은지        봉사활동 인증 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 조회 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 생성/수정/삭제 기능 추가
  * </pre>
  */
 @Mapper
 public interface AdminMapper {
     public int updateVolunteerStatus(UpdateVolunteerStatusRequestDTO request);
     public int updateVolunteerVerified(UpdateVolunteerStatusRequestDTO request);
+
+    int insertVolunteer(AdminVolunteerRequestDTO request);
+    int updateVolunteer(AdminVolunteerRequestDTO request);
+    int deleteVolunteer(long volunteerId);
+    List<AdminVolunteerResponseDTO> selectVolunteerList();
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/service/AdminService.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/service/AdminService.java
@@ -1,8 +1,12 @@
 package com.sbsj.dreamwing.admin.service;
 
 
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO;
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO;
 import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
+
+import java.util.List;
 
 /**
  * 관리자 서비스 인터페이스
@@ -16,9 +20,18 @@ import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
  * 2024.07.29   정은지        봉사활동 인증 후 포인트 부여 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 조회 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 생성/수정/삭제 기능 추가
  * </pre>
  */
 public interface AdminService {
     boolean approveVolunteerRequest(UpdateVolunteerStatusRequestDTO request) throws Exception;
     boolean awardVolunteerPoints(AwardVolunteerPointsRequestDTO request) throws Exception;
+
+
+
+    int createVolunteer(AdminVolunteerRequestDTO request);
+    int updateVolunteer(AdminVolunteerRequestDTO request);
+    int deleteVolunteer(long volunteerId);
+    List<AdminVolunteerResponseDTO> getVolunteerList();
 }

--- a/src/main/java/com/sbsj/dreamwing/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/admin/service/AdminServiceImpl.java
@@ -1,5 +1,7 @@
 package com.sbsj.dreamwing.admin.service;
 
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO;
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO;
 import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.admin.mapper.AdminMapper;
@@ -9,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 관리자 서비스 구현체
@@ -22,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
  * 2024.07.28  	정은지        최초 생성
  * 2024.07.28   정은지        봉사활동 승인 기능 추가
  * 2024.07.29   정은지        봉사활동 인증 후 포인트 부여 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 조회 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 생성/수정/삭제 기능 추가
  * </pre>
  */
 @Slf4j
@@ -51,5 +57,28 @@ public class AdminServiceImpl implements AdminService {
             log.error(e.getMessage());
             return false;
         }
+    }
+
+    @Override
+    @Transactional
+    public int createVolunteer(AdminVolunteerRequestDTO request) {
+        return mapper.insertVolunteer(request);
+    }
+
+    @Override
+    @Transactional
+    public int updateVolunteer(AdminVolunteerRequestDTO request) {
+        return mapper.updateVolunteer(request);
+    }
+
+    @Override
+    @Transactional
+    public int deleteVolunteer(long volunteerId) {
+        return mapper.deleteVolunteer(volunteerId);
+    }
+
+    @Override
+    public List<AdminVolunteerResponseDTO> getVolunteerList() {
+        return mapper.selectVolunteerList();
     }
 }

--- a/src/main/resources/com/sbsj/dreamwing/admin/mapper/AdminMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/admin/mapper/AdminMapper.xml
@@ -13,7 +13,8 @@
 * 2024.07.28   정은지         최초 생성
 * 2024.07.28   정은지         봉사활동 승인 기능 추가
 * 2024.07.29   정은지         봉사활동 인증 기능 추가
-*
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 조회 기능 추가
+ * 2024.07.30   임재성        봉사 & 멘토링 공고 글 생성/수정/삭제 기능 추가
 * </pre>
 -->
 <mapper namespace="com.sbsj.dreamwing.admin.mapper.AdminMapper">
@@ -30,4 +31,81 @@
         WHERE  VOLUNTEER_ID = #{volunteerId}
                AND USER_ID = #{userId}
     </update>
+
+    <!-- 봉사 공고 생성 -->
+    <insert id="insertVolunteer" parameterType="com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO">
+        INSERT INTO VOLUNTEER (
+            VOLUNTEER_ID,
+            TITLE,
+            CONTENT,
+            TYPE,
+            CATEGORY,
+            VOLUNTEER_START_DATE,
+            VOLUNTEER_END_DATE,
+            ADDRESS,
+            TOTAL_COUNT,
+            STATUS,
+            RECRUIT_START_DATE,
+            RECRUIT_END_DATE,
+            IMAGE_URL,
+            LATITUDE,
+            LONGITUDE
+        )
+        VALUES (
+                   SEQ_VOLUNTEER.NEXTVAL,
+                   #{title},
+                   #{content},
+                   #{type},
+                   #{category},
+                   #{startDate},
+                   #{endDate},
+                   #{address},
+                   #{totalCount},
+                   #{status},
+                   #{recruitStartDate},
+                   #{recruitEndDate},
+                   #{imageUrl},
+                   #{latitude},
+                   #{longitude}
+               )
+    </insert>
+
+    <!-- 봉사 공고 수정 -->
+    <update id="updateVolunteer" parameterType="com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO">
+        UPDATE VOLUNTEER
+        SET
+            TITLE = #{title},
+            CONTENT = #{content},
+            TYPE = #{type},
+            CATEGORY = #{category},
+            VOLUNTEER_START_DATE = #{startDate},
+            VOLUNTEER_END_DATE = #{endDate},
+            ADDRESS = #{address},
+            TOTAL_COUNT = #{totalCount},
+            STATUS = #{status},
+            RECRUIT_START_DATE = #{recruitStartDate},
+            RECRUIT_END_DATE = #{recruitEndDate},
+            IMAGE_URL = #{imageUrl},
+            LATITUDE = #{latitude},
+            LONGITUDE = #{longitude}
+        WHERE VOLUNTEER_ID = #{volunteerId}
+    </update>
+
+    <!-- 봉사 공고 삭제 -->
+    <delete id="deleteVolunteer" parameterType="long">
+        DELETE FROM VOLUNTEER
+        WHERE VOLUNTEER_ID = #{volunteerId}
+    </delete>
+
+    <!-- 봉사 공고 목록 조회 -->
+    <select id="selectVolunteerList" resultType="com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO">
+        SELECT
+            V.VOLUNTEER_ID AS volunteerId,
+            V.TITLE AS title,
+            V.TYPE AS type,
+            (SELECT COUNT(*) FROM USER_VOLUNTEER UV WHERE UV.VOLUNTEER_ID = V.VOLUNTEER_ID) AS currentPerson
+        FROM VOLUNTEER V
+    </select>
+
+
 </mapper>

--- a/src/test/java/com/sbsj/dreamwing/admin/mapper/AdminMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/admin/mapper/AdminMapperTests.java
@@ -1,5 +1,7 @@
 package com.sbsj.dreamwing.admin.mapper;
 
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO;
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.mission.domain.QuizVO;
 import com.sbsj.dreamwing.mission.dto.AwardPointsRequestDTO;
@@ -10,8 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,5 +71,85 @@ public class AdminMapperTests {
 
         // then
         Assertions.assertEquals(success, 1);
+    }
+
+
+    @Test
+    @DisplayName("봉사 공고 생성 매퍼 테스트")
+    public void testInsertVolunteer() {
+        // given
+        AdminVolunteerRequestDTO dto = new AdminVolunteerRequestDTO();
+        dto.setTitle("테스트 봉사 공고");
+        dto.setContent("테스트 봉사 공고 내용");
+        dto.setType(1);
+        dto.setCategory(2);
+        dto.setStartDate(Timestamp.valueOf("2024-08-01 09:00:00"));
+        dto.setEndDate(Timestamp.valueOf("2024-08-01 12:00:00"));
+        dto.setAddress("테스트 주소");
+        dto.setTotalCount(20);
+        dto.setStatus(0);
+        dto.setRecruitStartDate(Timestamp.valueOf("2024-07-01 00:00:00"));
+        dto.setRecruitEndDate(Timestamp.valueOf("2024-07-31 23:59:59"));
+        dto.setImageUrl("https://example.com/image.jpg");
+        dto.setLatitude("37.5665");
+        dto.setLongitude("126.978");
+
+        // when
+        int success = mapper.insertVolunteer(dto);
+
+        // then
+        Assertions.assertEquals(1, success);
+    }
+
+    @Test
+    @DisplayName("봉사 공고 수정 매퍼 테스트")
+    public void testUpdateVolunteer() {
+        // given
+        AdminVolunteerRequestDTO dto = new AdminVolunteerRequestDTO();
+        dto.setVolunteerId(1L); // Assuming this ID exists
+        dto.setTitle("수정된 봉사 공고");
+        dto.setContent("수정된 봉사 공고 내용");
+        dto.setType(1);
+        dto.setCategory(2);
+        dto.setStartDate(Timestamp.valueOf("2024-08-01 09:00:00"));
+        dto.setEndDate(Timestamp.valueOf("2024-08-01 12:00:00"));
+        dto.setAddress("수정된 주소");
+        dto.setTotalCount(30);
+        dto.setStatus(1);
+        dto.setRecruitStartDate(Timestamp.valueOf("2024-07-01 00:00:00"));
+        dto.setRecruitEndDate(Timestamp.valueOf("2024-07-31 23:59:59"));
+        dto.setImageUrl("https://example.com/new_image.jpg");
+        dto.setLatitude("37.567");
+        dto.setLongitude("126.979");
+
+        // when
+        int success = mapper.updateVolunteer(dto);
+
+        // then
+        Assertions.assertEquals(1, success);
+    }
+
+    @Test
+    @DisplayName("봉사 공고 삭제 매퍼 테스트")
+    public void testDeleteVolunteer() {
+        // given
+        long volunteerId = 7L; // Assuming this ID exists
+
+        // when
+        int success = mapper.deleteVolunteer(volunteerId);
+
+        // then
+        Assertions.assertEquals(1, success);
+    }
+
+    @Test
+    @DisplayName("봉사 공고 목록 조회 매퍼 테스트")
+    public void testSelectVolunteerList() {
+        // when
+        List<AdminVolunteerResponseDTO> list = mapper.selectVolunteerList();
+
+        // then
+        Assertions.assertNotNull(list);
+        Assertions.assertFalse(list.isEmpty());
     }
 }

--- a/src/test/java/com/sbsj/dreamwing/admin/service/AdminServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/admin/service/AdminServiceTests.java
@@ -1,5 +1,7 @@
 package com.sbsj.dreamwing.admin.service;
 
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerRequestDTO;
+import com.sbsj.dreamwing.admin.dto.AdminVolunteerResponseDTO;
 import com.sbsj.dreamwing.admin.dto.AwardVolunteerPointsRequestDTO;
 import com.sbsj.dreamwing.admin.dto.UpdateVolunteerStatusRequestDTO;
 import com.sbsj.dreamwing.mission.domain.QuizVO;
@@ -10,8 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -70,5 +74,84 @@ public class AdminServiceTests {
 
         // then
         assertTrue(success, "봉사활동 인증 실패");
+    }
+
+    @Test
+    @DisplayName("봉사 공고 생성 서비스 테스트")
+    public void testCreateVolunteer() {
+        // given
+        AdminVolunteerRequestDTO dto = new AdminVolunteerRequestDTO();
+        dto.setTitle("서비스 생성 봉사 공고");
+        dto.setContent("서비스 생성 봉사 공고 내용");
+        dto.setType(1);
+        dto.setCategory(2);
+        dto.setStartDate(Timestamp.valueOf("2024-08-01 09:00:00"));
+        dto.setEndDate(Timestamp.valueOf("2024-08-01 12:00:00"));
+        dto.setAddress("서비스 생성 주소");
+        dto.setTotalCount(20);
+        dto.setStatus(0);
+        dto.setRecruitStartDate(Timestamp.valueOf("2024-07-01 00:00:00"));
+        dto.setRecruitEndDate(Timestamp.valueOf("2024-07-31 23:59:59"));
+        dto.setImageUrl("https://example.com/service_image.jpg");
+        dto.setLatitude("37.5665");
+        dto.setLongitude("126.978");
+
+        // when
+        int success = service.createVolunteer(dto);
+
+        // then
+        Assertions.assertTrue(success > 0, "봉사 공고 생성 실패");
+    }
+
+    @Test
+    @DisplayName("봉사 공고 수정 서비스 테스트")
+    public void testUpdateVolunteer() {
+        // given
+        AdminVolunteerRequestDTO dto = new AdminVolunteerRequestDTO();
+        dto.setVolunteerId(1L); // Assuming this ID exists
+        dto.setTitle("서비스 수정 봉사 공고");
+        dto.setContent("서비스 수정 봉사 공고 내용");
+        dto.setType(1);
+        dto.setCategory(2);
+        dto.setStartDate(Timestamp.valueOf("2024-08-01 09:00:00"));
+        dto.setEndDate(Timestamp.valueOf("2024-08-01 12:00:00"));
+        dto.setAddress("서비스 수정 주소");
+        dto.setTotalCount(30);
+        dto.setStatus(1);
+        dto.setRecruitStartDate(Timestamp.valueOf("2024-07-01 00:00:00"));
+        dto.setRecruitEndDate(Timestamp.valueOf("2024-07-31 23:59:59"));
+        dto.setImageUrl("https://example.com/service_update_image.jpg");
+        dto.setLatitude("37.567");
+        dto.setLongitude("126.979");
+
+        // when
+        int success = service.updateVolunteer(dto);
+
+        // then
+        Assertions.assertTrue(success > 0, "봉사 공고 수정 실패");
+    }
+
+    @Test
+    @DisplayName("봉사 공고 삭제 서비스 테스트")
+    public void testDeleteVolunteer() {
+        // given
+        long volunteerId = 8L; // Assuming this ID exists
+
+        // when
+        int success = service.deleteVolunteer(volunteerId);
+
+        // then
+        Assertions.assertTrue(success > 0, "봉사 공고 삭제 실패");
+    }
+
+    @Test
+    @DisplayName("봉사 공고 목록 조회 서비스 테스트")
+    public void testGetVolunteerList() {
+        // when
+        List<AdminVolunteerResponseDTO> list = service.getVolunteerList();
+
+        // then
+        Assertions.assertNotNull(list);
+        Assertions.assertFalse(list.isEmpty());
     }
 }


### PR DESCRIPTION


# 💡 PR 요약
관리자 페이지 내 봉사 & 멘토링 모집 공고 글 생성/수정/삭제/조회 API 작성 했습니다.

## ⭐️ 관련 이슈
- closes : #37 
- 
## ⭐️ 작업한 내용
- 관리자 페이지 내 모집 공고 글 생성,수정,삭제,조회
- 생성 시 위도와 경도 추가하게끔 volunteer Table 에 위도와 경도 컬럼 추가
- 매퍼테스트,서비스테스트,포스트맨테스트

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
