### PR TITLE
Feat : 후원 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
+++ b/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sbsj.dreamwing.user.controller;
 
-import com.sbsj.dreamwing.user.domain.PointVO;
+import com.sbsj.dreamwing.user.domain.UserPointVO;
+import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.dto.LoginRequestDTO;
 import com.sbsj.dreamwing.user.dto.UserDTO;
 import com.sbsj.dreamwing.user.dto.UserUpdateDTO;
@@ -30,7 +31,7 @@ import java.util.List;
  *  2024.07.30      정은찬                       로그인 기능 API 추가
  *  2024.07.31      정은찬                       회원탈퇴 기능 API 및 회원 정보 가져오기 API 추가
  *  2024.07.31      정은찬                       회원 정보 업데이트 API 및 로그아웃 API 추가
- *  2024.07.31      정은찬                       포인트 내역 조회 API 추가
+ *  2024.07.31      정은찬                       포인트 내역 조회 API 및 후원 내역 조회 API 추가
  * </pre>
  */
 @RestController
@@ -141,15 +142,28 @@ public class UserController {
     }
 
     @GetMapping("/getPointList")
-    public ResponseEntity<ApiResponse<List<PointVO>>> getPointList() {
+    public ResponseEntity<ApiResponse<List<UserPointVO>>> getUserPointList() {
         // SecurityContext에서 Authentication 객체를 가져옵니다.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
         // 여기서는 UserDetails의 `getUsername` 메서드를 사용한다고 가정합니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
 
-        List<PointVO> pointList = userService.getPointList(userId);
+        List<UserPointVO> pointList = userService.getUserPointList(userId);
 
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, pointList));
+    }
+
+    @GetMapping("/getSupportList")
+    public ResponseEntity<ApiResponse<List<UserSupportVO>>> getUserSupportList() {
+        // SecurityContext에서 Authentication 객체를 가져옵니다.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // UserDetails 객체에서 userId를 가져옵니다.
+        // 여기서는 UserDetails의 `getUsername` 메서드를 사용한다고 가정합니다.
+        long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
+
+        List<UserSupportVO> supportList = userService.getUserSupportList(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, supportList));
     }
 }

--- a/src/main/java/com/sbsj/dreamwing/user/domain/UserPointVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/UserPointVO.java
@@ -1,0 +1,21 @@
+package com.sbsj.dreamwing.user.domain;
+
+import lombok.Data;
+
+/**
+ * 포인트 내역 정보를 담는 VO
+ * @author 정은찬
+ * @since 2024.07.31
+ *
+ * <pre>
+ * 수정일             수정자                      수정내용
+ * ----------  ----------------    ---------------------------------
+ * 2024.07.31       정은찬                     최초 생성
+ * </pre>
+ */
+@Data
+public class UserPointVO {
+    String ActivityTitle;
+    int point;
+    String createdDate;
+}

--- a/src/main/java/com/sbsj/dreamwing/user/domain/UserSupportVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/UserSupportVO.java
@@ -2,10 +2,8 @@ package com.sbsj.dreamwing.user.domain;
 
 import lombok.Data;
 
-import java.sql.Timestamp;
-
 /**
- * 포인트 내역 정보를 담는 VO
+ * 후원 내역 정보를 담는 VO
  * @author 정은찬
  * @since 2024.07.31
  *
@@ -16,8 +14,8 @@ import java.sql.Timestamp;
  * </pre>
  */
 @Data
-public class PointVO {
-    private String ActivityTitle;
+public class UserSupportVO {
+    String title;
     int point;
     String createdDate;
 }

--- a/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.sbsj.dreamwing.user.mapper;
 
-import com.sbsj.dreamwing.user.domain.PointVO;
+import com.sbsj.dreamwing.user.domain.UserPointVO;
+import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
 import com.sbsj.dreamwing.user.dto.UserDTO;
 import com.sbsj.dreamwing.user.dto.UserUpdateDTO;
@@ -22,7 +23,7 @@ import java.util.Optional;
  *  2024.07.29      정은찬                      로그인 아이디 존재 여부 확인
  *  2024.07.30      정은찬                      loginId를 통해 회원 정보 가져오기
  *  2024.07.31      정은찬                      userId를 통해 회원 정보 가져오기
- *  2024.07.31      정은찬                      회원 정보 업데이트하기 및 포인트 내역 가져오기
+ *  2024.07.31      정은찬                      회원 정보 업데이트하기 및 포인트 내역, 후원 내역 가져오기
  * </pre>
  */
 @Mapper
@@ -33,5 +34,7 @@ public interface UserMapper {
     Optional<UserDTO> selectUserByUserId(long userId);
     int withdraw(long userId);
     int updateUserInfo(UserUpdateDTO userUpdateDTO);
-    List<PointVO> getPointVOList(long userId);
+    List<UserPointVO> getUserPointVOList(long userId);
+    List<UserSupportVO> getUserSupportVOList(long userId);
+
 }

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.sbsj.dreamwing.user.service;
 
-import com.sbsj.dreamwing.user.domain.PointVO;
-import com.sbsj.dreamwing.user.domain.UserVO;
+import com.sbsj.dreamwing.user.domain.UserPointVO;
+import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.dto.LoginRequestDTO;
 import com.sbsj.dreamwing.user.dto.SignUpRequestDTO;
 import com.sbsj.dreamwing.user.dto.UserDTO;
@@ -21,7 +21,7 @@ import java.util.List;
  *  2024.07.29      정은찬                       로그인 기능
  *  2024.07.31      정은찬                      회원탈퇴 기능 및 회원 정보 가져오기 기능 추가
  *  2024.07.31      정은찬                      회원 정보 업데이트 기능 및 로그아웃 기능 추가
- *  2024.07.31      정은찬                      포인트 내역 조회 기능 추가
+ *  2024.07.31      정은찬                      포인트 내역 조회 기능 및 후원 내역 조회 기능 추가
  * </pre>
  */
 public interface UserService {
@@ -31,5 +31,6 @@ public interface UserService {
     public UserDTO getUserInfo(long userId);
     public boolean updateUserInfo(UserUpdateDTO userUpdateDTO);
     public void logout(long userId);
-    public List<PointVO> getPointList(long userId);
+    public List<UserPointVO> getUserPointList(long userId);
+    public List<UserSupportVO> getUserSupportList(long userId);
 }

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sbsj.dreamwing.user.service;
 
-import com.sbsj.dreamwing.user.domain.PointVO;
+import com.sbsj.dreamwing.user.domain.UserPointVO;
+import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
 import com.sbsj.dreamwing.user.dto.LoginRequestDTO;
 import com.sbsj.dreamwing.user.dto.SignUpRequestDTO;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
  *  2024.07.29      정은찬                      로그인 기능 추가
  *  2024.07.31      정은찬                      회원탈퇴 기능 및 회원 정보 가져오기 기능 추가
  *  2024.07.31      정은찬                      회원 정보 업데이트 기능 및 로그아웃 기능 추가
- *  2024.07.31      정은찬                      포인트 내역 조회 기능 추가
+ *  2024.07.31      정은찬                      포인트 내역 조회 기능 및 후원 내역 조회 기능 추가
  * </pre>
  */
 @Service
@@ -141,8 +142,13 @@ public class UserServiceImpl implements UserService {
 
     }
 
-    public List<PointVO> getPointList(long userId) {
-        List<PointVO> pointList = userMapper.getPointVOList(userId);
-        return pointList;
+    public List<UserPointVO> getUserPointList(long userId) {
+        List<UserPointVO> userPointList = userMapper.getUserPointVOList(userId);
+        return userPointList;
+    }
+
+    public List<UserSupportVO> getUserSupportList(long userId) {
+        List<UserSupportVO> userSupportList = userMapper.getUserSupportVOList(userId);
+        return userSupportList;
     }
 }

--- a/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
@@ -86,11 +86,19 @@
         WHERE USER_ID = #{userId}
     </update>
 
-    <select id="getPointVOList" resultType="PointVO">
+    <select id="getUserPointVOList" resultType="UserPointVO">
         SELECT ACTIVITY_TITLE,
                POINT,
                TO_CHAR(CREATED_DATE AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS CREATED_DATE
         FROM POINT_HISTORY
         WHERE USER_ID = #{userId}
+    </select>
+
+    <select id="getUserSupportVOList" resultType="UserSupportVO">
+        SELECT S.TITLE,
+               S_HIST.POINT,
+               TO_CHAR(S_HIST.CREATED_DATE AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS CREATED_DATE
+        FROM SUPPORT S, SUPPORT_HISTORY S_HIST
+        WHERE S.SUPPORT_ID = S_HIST.SUPPORT_ID AND S_HIST.USER_ID = #{userId}
     </select>
 </mapper>

--- a/src/test/java/com/sbsj/dreamwing/user/mapper/UserMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/user/mapper/UserMapperTests.java
@@ -1,6 +1,7 @@
 package com.sbsj.dreamwing.user.mapper;
 
-import com.sbsj.dreamwing.user.domain.PointVO;
+import com.sbsj.dreamwing.user.domain.UserPointVO;
+import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
 
 import com.sbsj.dreamwing.user.dto.UserDTO;
@@ -97,8 +98,14 @@ public class UserMapperTests {
     }
 
     @Test
-    public void getPointVOListTest() {
-        List<PointVO> pointVOList = userMapper.getPointVOList(1);
-        log.info(pointVOList.toString());
+    public void getUserPointVOListTest() {
+        List<UserPointVO> userPointVOList = userMapper.getUserPointVOList(1);
+        log.info(userPointVOList.toString());
+    }
+
+    @Test
+    public void getUserSupportVOListTest() {
+        List<UserSupportVO> userSupportVOList = userMapper.getUserSupportVOList(1);
+        log.info(userSupportVOList.toString());
     }
 }

--- a/src/test/java/com/sbsj/dreamwing/user/service/UserServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/user/service/UserServiceTests.java
@@ -1,7 +1,7 @@
 package com.sbsj.dreamwing.user.service;
 
-import com.sbsj.dreamwing.user.domain.PointVO;
-import com.sbsj.dreamwing.user.domain.UserVO;
+import com.sbsj.dreamwing.user.domain.UserPointVO;
+import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.dto.LoginRequestDTO;
 import com.sbsj.dreamwing.user.dto.SignUpRequestDTO;
 import com.sbsj.dreamwing.user.dto.UserDTO;
@@ -96,7 +96,13 @@ public class UserServiceTests {
 
     @Test
     public void getPointListTest() {
-        List<PointVO> pointList = userService.getPointList(1);
-        log.info(pointList.toString());
+        List<UserPointVO> userPointList = userService.getUserPointList(8);
+        log.info(userPointList.toString());
+    }
+
+    @Test
+    public void getSupportListTest() {
+        List<UserSupportVO> userSupportList = userService.getUserSupportList(1);
+        log.info(userSupportList.toString());
     }
 }


### PR DESCRIPTION
# 💡 PR 요약
후원 내역 조회 기능을 구현하는 작업

## ⭐️ 관련 이슈
- closes : #49 
- 
## ⭐️ 작업한 내용
- 후원 내역 조회 API 작성
- SUPPORT 테이블과 SUPPORT_HISTORY 테이블 조인을 통해 후원 내역 가져오기

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
