### PR TITLE
Refactor : 프로필 이미지 S3 업로드 및 이미지 url 저장 방식 수정

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
+++ b/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
@@ -16,7 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
+++ b/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
@@ -8,13 +8,17 @@ import com.sbsj.dreamwing.user.dto.UserUpdateDTO;
 import com.sbsj.dreamwing.user.service.UserService;
 import com.sbsj.dreamwing.user.dto.SignUpRequestDTO;
 import com.sbsj.dreamwing.util.ApiResponse;
+import com.sbsj.dreamwing.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -40,8 +44,9 @@ import java.util.List;
 public class UserController {
     private final UserService userService;
 
-    @PostMapping("/signUp")
-    public ResponseEntity<ApiResponse<Void>> signUp(@RequestBody SignUpRequestDTO signUpRequestDTO) throws Exception {
+    @PostMapping(value = "/signUp", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> signUp(@ModelAttribute SignUpRequestDTO signUpRequestDTO) throws Exception {
+
         String result = userService.signUp(signUpRequestDTO);
 
         if (result.equals("사용자 등록 성공")) {
@@ -103,17 +108,14 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, userDTO));
     }
 
-    @PostMapping("/update")
-    public ResponseEntity<ApiResponse<Void>> update(@RequestBody UserUpdateDTO userUpdateDTO) throws Exception {
+    @PostMapping(value = "/update", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Void>> update(@ModelAttribute UserUpdateDTO userUpdateDTO) throws Exception {
         // SecurityContext에서 Authentication 객체를 가져옵니다.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
-        // 여기서는 UserDetails의 `getUsername` 메서드를 사용한다고 가정합니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
 
-        userUpdateDTO.setUserId(userId);
-
-        Boolean result = userService.updateUserInfo(userUpdateDTO);
+        Boolean result = userService.updateUserInfo(userId, userUpdateDTO);
 
         if (result) {
             return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));

--- a/src/main/java/com/sbsj/dreamwing/user/domain/UserVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/UserVO.java
@@ -18,7 +18,7 @@ import lombok.Builder;
 @Data
 @Builder
 public class UserVO {
-    int userId;
+    long userId;
     String loginId;
     String password;
     String name;

--- a/src/main/java/com/sbsj/dreamwing/user/dto/SignUpRequestDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/dto/SignUpRequestDTO.java
@@ -1,6 +1,7 @@
 package com.sbsj.dreamwing.user.dto;
 
 import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 사용자 회원가입 정보를 담는 DTO 클래스
@@ -11,6 +12,7 @@ import lombok.Data;
  * 수정일             수정자                      수정내용
  * ----------  ----------------    ---------------------------------
  * 2024.07.28       정은찬                      최초 생성
+ * 2024.07.31       정은찬                MultipartFile 변수 생성
  * </pre>
  */
 @Data
@@ -19,5 +21,6 @@ public class SignUpRequestDTO {
     private String password;
     private String name;
     private String phone;
+    private MultipartFile imageFile;
     private String profileImageUrl;
 }

--- a/src/main/java/com/sbsj/dreamwing/user/dto/UserDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/dto/UserDTO.java
@@ -35,6 +35,7 @@ public class UserDTO implements UserDetails {
     private String name;
     private String phone;
     private int totalPoint;
+    private int withdraw;
     private String profileImageUrl;
     private Timestamp createdDate;
 

--- a/src/main/java/com/sbsj/dreamwing/user/dto/UserUpdateDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/dto/UserUpdateDTO.java
@@ -2,6 +2,7 @@ package com.sbsj.dreamwing.user.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * 사용자 업데이트 정보를 담는 DTO 클래스
@@ -12,14 +13,15 @@ import lombok.Data;
  * 수정일             수정자                      수정내용
  * ----------  ----------------    ---------------------------------
  * 2024.07.31       정은찬                      최초 생성
+ * 2024.07.31       정은찬                MultipartFile 변수 생성
  * </pre>
  */
 @Data
 @Builder
 public class UserUpdateDTO {
-    long userId;
     String password;
     String name;
     String phone;
+    private MultipartFile imageFile;
     private String profileImageUrl;
 }

--- a/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
@@ -33,7 +33,7 @@ public interface UserMapper {
     Optional<UserDTO> selectUserByLoginId(String loginId);
     Optional<UserDTO> selectUserByUserId(long userId);
     int withdraw(long userId);
-    int updateUserInfo(UserUpdateDTO userUpdateDTO);
+    int updateUserInfo(UserVO userVO);
     List<UserPointVO> getUserPointVOList(long userId);
     List<UserSupportVO> getUserSupportVOList(long userId);
 

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
@@ -22,6 +22,7 @@ import java.util.List;
  *  2024.07.31      정은찬                      회원탈퇴 기능 및 회원 정보 가져오기 기능 추가
  *  2024.07.31      정은찬                      회원 정보 업데이트 기능 및 로그아웃 기능 추가
  *  2024.07.31      정은찬                      포인트 내역 조회 기능 및 후원 내역 조회 기능 추가
+ *  2024.07.31      정은찬                      회원가입 및 회원 정보 업데이트 프로필 이미지 S3 업로드 기능 추가
  * </pre>
  */
 public interface UserService {
@@ -29,7 +30,7 @@ public interface UserService {
     public String login(LoginRequestDTO loginRequestDTO) throws Exception;
     public boolean withdraw(long userId);
     public UserDTO getUserInfo(long userId);
-    public boolean updateUserInfo(UserUpdateDTO userUpdateDTO);
+    public boolean updateUserInfo(long userId, UserUpdateDTO userUpdateDTO);
     public void logout(long userId);
     public List<UserPointVO> getUserPointList(long userId);
     public List<UserSupportVO> getUserSupportList(long userId);

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
@@ -9,11 +9,13 @@ import com.sbsj.dreamwing.user.dto.UserDTO;
 import com.sbsj.dreamwing.user.dto.UserUpdateDTO;
 import com.sbsj.dreamwing.user.mapper.UserMapper;
 import com.sbsj.dreamwing.util.JwtTokenProvider;
+import com.sbsj.dreamwing.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.sql.Timestamp;
 import java.util.Collections;
@@ -34,6 +36,7 @@ import java.util.concurrent.TimeUnit;
  *  2024.07.31      정은찬                      회원탈퇴 기능 및 회원 정보 가져오기 기능 추가
  *  2024.07.31      정은찬                      회원 정보 업데이트 기능 및 로그아웃 기능 추가
  *  2024.07.31      정은찬                      포인트 내역 조회 기능 및 후원 내역 조회 기능 추가
+ *  2024.07.31      정은찬                      회원가입 및 회원 정보 업데이트 프로필 이미지 S3 업로드 기능 추가
  * </pre>
  */
 @Service
@@ -44,6 +47,7 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
+    private final S3Uploader s3Uploader;
 
     @Transactional
     public String signUp(SignUpRequestDTO signUpRequestDTO) {
@@ -51,6 +55,17 @@ public class UserServiceImpl implements UserService {
         if(userMapper.checkLoginIdExistence(signUpRequestDTO.getLoginId()) != null) {
             return "중복 아이디 존재";
         }
+
+        // 이미지 파일 처리
+        String imageUrl = "https://dreamwing.s3.ap-northeast-2.amazonaws.com/image/default.jpg";
+
+        MultipartFile imageFile = signUpRequestDTO.getImageFile();
+        if (imageFile != null && !imageFile.isEmpty()) {
+            imageUrl = s3Uploader.uploadFile(signUpRequestDTO.getImageFile());
+        }
+
+        signUpRequestDTO.setProfileImageUrl(imageUrl);
+
         // 현재 시간을 TIMESTAMP로 설정
         Timestamp currentTimestamp = new Timestamp(new Date().getTime());
 
@@ -77,7 +92,7 @@ public class UserServiceImpl implements UserService {
         UserDTO userDTO = userMapper.selectUserByLoginId(loginRequestDTO.getLoginId())
                 .orElseThrow(() -> new RuntimeException("잘못된 아이디입니다"));
 
-        if(userDTO == null) {
+        if(userDTO == null || userDTO.getWithdraw() == 1) {
             throw new Exception("잘못된 아이디입니다.");
         }
         else {
@@ -123,9 +138,24 @@ public class UserServiceImpl implements UserService {
         return userDTO;
     }
 
-    public boolean updateUserInfo(UserUpdateDTO userUpdateDTO) {
+    public boolean updateUserInfo(long userId, UserUpdateDTO userUpdateDTO) {
         userUpdateDTO.setPassword(passwordEncoder.encode(userUpdateDTO.getPassword()));
-        int result = userMapper.updateUserInfo(userUpdateDTO);
+
+        MultipartFile imageFile = userUpdateDTO.getImageFile();
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String imageUrl = s3Uploader.uploadFile(userUpdateDTO.getImageFile());
+            userUpdateDTO.setProfileImageUrl(imageUrl);
+        }
+
+        UserVO userVO = UserVO.builder()
+                .userId(userId)
+                .name(userUpdateDTO.getName())
+                .password(userUpdateDTO.getPassword())
+                .phone(userUpdateDTO.getPhone())
+                .profileImageUrl(userUpdateDTO.getProfileImageUrl())
+                .build();
+
+        int result = userMapper.updateUserInfo(userVO);
 
         if(result == 1) {
             return true;

--- a/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
@@ -49,7 +49,8 @@
     <select id="selectUserByLoginId" resultType="UserDTO">
         SELECT USER_ID,
                LOGIN_ID,
-               PASSWORD
+               PASSWORD,
+               WITHDRAW
         FROM   USER_INFO
         WHERE  LOGIN_ID = #{loginId}
     </select>
@@ -77,7 +78,7 @@
         WHERE  USER_ID = #{userId}
     </select>
 
-    <update id="updateUserInfo" parameterType="UserUpdateDTO">
+    <update id="updateUserInfo" parameterType="UserVO">
         UPDATE USER_INFO
         SET PASSWORD = #{password},
             NAME = #{name},

--- a/src/test/java/com/sbsj/dreamwing/user/mapper/UserMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/user/mapper/UserMapperTests.java
@@ -85,7 +85,7 @@ public class UserMapperTests {
 
     @Test
     public void updateUserInfoTest() {
-        UserUpdateDTO userUpdateDTO = UserUpdateDTO.builder()
+        UserVO userVO = UserVO.builder()
                 .userId(2)
                 .password("test1222")
                 .name("updateTest")
@@ -93,7 +93,7 @@ public class UserMapperTests {
                 .profileImageUrl("updateImage")
                 .build();
 
-        int result = userMapper.updateUserInfo(userUpdateDTO);
+        int result = userMapper.updateUserInfo(userVO);
         Assertions.assertEquals(result, 1);
     }
 

--- a/src/test/java/com/sbsj/dreamwing/user/service/UserServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/user/service/UserServiceTests.java
@@ -82,15 +82,15 @@ public class UserServiceTests {
 
     @Test
     public void updateUserInfoTest() {
+        long userId = 7;
         UserUpdateDTO userUpdateDTO = UserUpdateDTO.builder()
-                .userId(2)
                 .password("test1222")
                 .name("updateTest")
                 .phone("11111111111")
                 .profileImageUrl("updateImage")
                 .build();
 
-        Boolean result = userService.updateUserInfo(userUpdateDTO);
+        Boolean result = userService.updateUserInfo(userId, userUpdateDTO);
         Assertions.assertEquals(result, true);
     }
 


### PR DESCRIPTION
# 💡 PR 요약
프로필 이미지 S3 업로드 및 이미지 url 저장 방식 수정 작업

## ⭐️ 관련 이슈
- closes : #54 
- 
## ⭐️ 작업한 내용
- 프로필 이미지 S3 업로드
- S3 이미지 저장 url을 프로필 이미지 url에 저장

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 