### PR TITLE
Feat : 마이페이지 사용자 정보 조회 기능 작성

### DIFF
--- a/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
+++ b/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
@@ -33,7 +33,8 @@ import java.util.List;
  *  2024.07.31      정은찬                       회원 정보 업데이트 API 및 로그아웃 API 추가
  *  2024.07.31      정은찬                       포인트 내역 조회 API 및 후원 내역 조회 API 추가
  *  2024.08.02      정은찬                       로그인 아이디 존재 여부 확인 API 추가
- *  
+ *  2024.08.04      정은찬                       마이페이지 사용자 정보 API 추가
+ *
  * </pre>
  */
 @RestController
@@ -84,7 +85,7 @@ public class UserController {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
-        
+
         boolean result = userService.withdraw(userId);
         if (result) {
             return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK));
@@ -146,7 +147,6 @@ public class UserController {
         // SecurityContext에서 Authentication 객체를 가져옵니다.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
-        // 여기서는 UserDetails의 `getUsername` 메서드를 사용한다고 가정합니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
 
         List<UserPointVO> pointList = userService.getUserPointList(userId);
@@ -159,7 +159,6 @@ public class UserController {
         // SecurityContext에서 Authentication 객체를 가져옵니다.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
-        // 여기서는 UserDetails의 `getUsername` 메서드를 사용한다고 가정합니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
 
         List<UserSupportVO> supportList = userService.getUserSupportList(userId);
@@ -174,6 +173,17 @@ public class UserController {
         boolean result = userService.checkExistLoginId(loginIdDTO);
 
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, result));
+    }
+    @GetMapping("/getMyPageInfo")
+    public ResponseEntity<ApiResponse<MyPageDTO>> getMyPageInfo() {
+        // SecurityContext에서 Authentication 객체를 가져옵니다.
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        // UserDetails 객체에서 userId를 가져옵니다.
+        long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
+
+        MyPageDTO myPageDTO = userService.getMyPageInfo(userId);
+
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, myPageDTO));
     }
 
 }

--- a/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
+++ b/src/main/java/com/sbsj/dreamwing/user/controller/UserController.java
@@ -1,11 +1,10 @@
 package com.sbsj.dreamwing.user.controller;
 
-import com.sbsj.dreamwing.user.domain.UserPointVO;
-import com.sbsj.dreamwing.user.domain.UserSupportVO;
+import com.sbsj.dreamwing.user.domain.MyPointVO;
+import com.sbsj.dreamwing.user.domain.MySupportVO;
 import com.sbsj.dreamwing.user.dto.*;
 import com.sbsj.dreamwing.user.service.UserService;
 import com.sbsj.dreamwing.util.ApiResponse;
-import com.sbsj.dreamwing.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -14,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -143,25 +141,25 @@ public class UserController {
     }
 
     @GetMapping("/getPointList")
-    public ResponseEntity<ApiResponse<List<UserPointVO>>> getUserPointList() {
+    public ResponseEntity<ApiResponse<List<MyPointVO>>> getUserPointList() {
         // SecurityContext에서 Authentication 객체를 가져옵니다.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
 
-        List<UserPointVO> pointList = userService.getUserPointList(userId);
+        List<MyPointVO> pointList = userService.getUserPointList(userId);
 
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, pointList));
     }
 
     @GetMapping("/getSupportList")
-    public ResponseEntity<ApiResponse<List<UserSupportVO>>> getUserSupportList() {
+    public ResponseEntity<ApiResponse<List<MySupportVO>>> getUserSupportList() {
         // SecurityContext에서 Authentication 객체를 가져옵니다.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         // UserDetails 객체에서 userId를 가져옵니다.
         long userId = ((UserDTO) authentication.getPrincipal()).getUserId();
 
-        List<UserSupportVO> supportList = userService.getUserSupportList(userId);
+        List<MySupportVO> supportList = userService.getUserSupportList(userId);
 
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, supportList));
     }

--- a/src/main/java/com/sbsj/dreamwing/user/domain/MyPointVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/MyPointVO.java
@@ -3,7 +3,7 @@ package com.sbsj.dreamwing.user.domain;
 import lombok.Data;
 
 /**
- * 사용자 후원 내역 정보를 담는 VO
+ * 사용자 포인트 내역 정보를 담는 VO
  * @author 정은찬
  * @since 2024.07.31
  *
@@ -14,8 +14,8 @@ import lombok.Data;
  * </pre>
  */
 @Data
-public class UserSupportVO {
-    String title;
+public class MyPointVO {
+    String ActivityTitle;
     int point;
     String createdDate;
 }

--- a/src/main/java/com/sbsj/dreamwing/user/domain/MySupportVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/MySupportVO.java
@@ -3,7 +3,7 @@ package com.sbsj.dreamwing.user.domain;
 import lombok.Data;
 
 /**
- * 사용자 포인트 내역 정보를 담는 VO
+ * 사용자 후원 내역 정보를 담는 VO
  * @author 정은찬
  * @since 2024.07.31
  *
@@ -14,8 +14,8 @@ import lombok.Data;
  * </pre>
  */
 @Data
-public class UserPointVO {
-    String ActivityTitle;
+public class MySupportVO {
+    String title;
     int point;
     String createdDate;
 }

--- a/src/main/java/com/sbsj/dreamwing/user/domain/MyVolunteerVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/MyVolunteerVO.java
@@ -3,19 +3,16 @@ package com.sbsj.dreamwing.user.domain;
 import lombok.Data;
 
 /**
- * 사용자 포인트 내역 정보를 담는 VO
+ * 사용자 봉사 내역 정보를 담는 VO
  * @author 정은찬
- * @since 2024.07.31
+ * @since 2024.08.03
  *
  * <pre>
  * 수정일             수정자                      수정내용
  * ----------  ----------------    ---------------------------------
- * 2024.07.31       정은찬                     최초 생성
+ * 2024.08.03       정은찬                     최초 생성
  * </pre>
  */
 @Data
-public class UserPointVO {
-    String ActivityTitle;
-    int point;
-    String createdDate;
+public class MyVolunteerVO {
 }

--- a/src/main/java/com/sbsj/dreamwing/user/domain/UserSupportVO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/domain/UserSupportVO.java
@@ -3,7 +3,7 @@ package com.sbsj.dreamwing.user.domain;
 import lombok.Data;
 
 /**
- * 후원 내역 정보를 담는 VO
+ * 사용자 후원 내역 정보를 담는 VO
  * @author 정은찬
  * @since 2024.07.31
  *

--- a/src/main/java/com/sbsj/dreamwing/user/dto/MyPageDTO.java
+++ b/src/main/java/com/sbsj/dreamwing/user/dto/MyPageDTO.java
@@ -1,0 +1,25 @@
+package com.sbsj.dreamwing.user.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 마이페이지 사용자 정보를 담는 DTO 클래스
+ * @author 정은찬
+ * @since 2024.08.04
+ *
+ * <pre>
+ * 수정일             수정자                      수정내용
+ * ----------  ----------------    ---------------------------------
+ * 2024.08.04       정은찬                      최초 생성
+ * </pre>
+ */
+@Data
+@Builder
+public class MyPageDTO {
+    private String name;
+    private String phone;
+    private String profileImageUrl;
+    private int totalPoint;
+    private int totalSupportPoint;
+}

--- a/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
@@ -3,8 +3,8 @@ package com.sbsj.dreamwing.user.mapper;
 import com.sbsj.dreamwing.user.domain.UserPointVO;
 import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
+import com.sbsj.dreamwing.user.domain.MyVolunteerVO;
 import com.sbsj.dreamwing.user.dto.UserDTO;
-import com.sbsj.dreamwing.user.dto.UserUpdateDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -20,10 +20,11 @@ import java.util.Optional;
  * 수정일        		수정자       				    수정내용
  * ----------  ----------------    ---------------------------------
  *  2024.07.28     	정은찬        		       최초 생성
- *  2024.07.29      정은찬                      로그인 아이디 존재 여부 확인
- *  2024.07.30      정은찬                      loginId를 통해 회원 정보 가져오기
- *  2024.07.31      정은찬                      userId를 통해 회원 정보 가져오기
- *  2024.07.31      정은찬                      회원 정보 업데이트하기 및 포인트 내역, 후원 내역 가져오기
+ *  2024.07.29      정은찬                      로그인 아이디 존재 여부 확인 추가
+ *  2024.07.30      정은찬                      loginId를 통해 회원 정보 가져오기 추가
+ *  2024.07.31      정은찬                      userId를 통해 회원 정보 가져오기 추가
+ *  2024.07.31      정은찬                      사용자 정보 업데이트하기 및 포인트 내역, 후원 내역 가져오기 추가
+ *  2024.08.03      정은찬                      사용자 총 후원 포인트 가져오기 및 사용자 봉사 내역 가져오기 추가
  * </pre>
  */
 @Mapper
@@ -36,5 +37,7 @@ public interface UserMapper {
     int updateUserInfo(UserVO userVO);
     List<UserPointVO> getUserPointVOList(long userId);
     List<UserSupportVO> getUserSupportVOList(long userId);
+    int selectTotalSupportPoint(long userId);
+    List<MyVolunteerVO> getUserVolunteerVOList(long userId);
 
 }

--- a/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
+++ b/src/main/java/com/sbsj/dreamwing/user/mapper/UserMapper.java
@@ -1,7 +1,7 @@
 package com.sbsj.dreamwing.user.mapper;
 
-import com.sbsj.dreamwing.user.domain.UserPointVO;
-import com.sbsj.dreamwing.user.domain.UserSupportVO;
+import com.sbsj.dreamwing.user.domain.MyPointVO;
+import com.sbsj.dreamwing.user.domain.MySupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
 import com.sbsj.dreamwing.user.domain.MyVolunteerVO;
 import com.sbsj.dreamwing.user.dto.UserDTO;
@@ -35,8 +35,8 @@ public interface UserMapper {
     Optional<UserDTO> selectUserByUserId(long userId);
     int withdraw(long userId);
     int updateUserInfo(UserVO userVO);
-    List<UserPointVO> getUserPointVOList(long userId);
-    List<UserSupportVO> getUserSupportVOList(long userId);
+    List<MyPointVO> getUserPointVOList(long userId);
+    List<MySupportVO> getUserSupportVOList(long userId);
     int selectTotalSupportPoint(long userId);
     List<MyVolunteerVO> getUserVolunteerVOList(long userId);
 

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
@@ -22,6 +22,7 @@ import java.util.List;
  *  2024.07.31      정은찬                      포인트 내역 조회 기능 및 후원 내역 조회 기능 추가
  *  2024.07.31      정은찬                      회원가입 및 회원 정보 업데이트 프로필 이미지 S3 업로드 기능 추가
  *  2024.08.02      정은찬                      로그인 아이디 존재 여부 확인 기능 추가
+ *  2024.08.03      정은찬                      마이페이지 사용자 정보 조회 기능 추가
  * </pre>
  */
 public interface UserService {
@@ -34,4 +35,5 @@ public interface UserService {
     public List<UserPointVO> getUserPointList(long userId);
     public List<UserSupportVO> getUserSupportList(long userId);
     public Boolean checkExistLoginId(LoginIdDTO loginIdDTO);
+    public MyPageDTO getMyPageInfo(long userId);
 }

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.sbsj.dreamwing.user.service;
 
-import com.sbsj.dreamwing.user.domain.UserPointVO;
-import com.sbsj.dreamwing.user.domain.UserSupportVO;
+import com.sbsj.dreamwing.user.domain.MyPointVO;
+import com.sbsj.dreamwing.user.domain.MySupportVO;
 import com.sbsj.dreamwing.user.dto.*;
 
 import java.util.List;
@@ -32,8 +32,8 @@ public interface UserService {
     public UserInfoDTO getUserInfo(long userId);
     public boolean updateUserInfo(long userId, UserUpdateDTO userUpdateDTO);
     public void logout(long userId);
-    public List<UserPointVO> getUserPointList(long userId);
-    public List<UserSupportVO> getUserSupportList(long userId);
+    public List<MyPointVO> getUserPointList(long userId);
+    public List<MySupportVO> getUserSupportList(long userId);
     public Boolean checkExistLoginId(LoginIdDTO loginIdDTO);
     public MyPageDTO getMyPageInfo(long userId);
 }

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
@@ -1,8 +1,8 @@
 package com.sbsj.dreamwing.user.service;
 
 import com.sbsj.dreamwing.support.mapper.SupportMapper;
-import com.sbsj.dreamwing.user.domain.UserPointVO;
-import com.sbsj.dreamwing.user.domain.UserSupportVO;
+import com.sbsj.dreamwing.user.domain.MyPointVO;
+import com.sbsj.dreamwing.user.domain.MySupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
 import com.sbsj.dreamwing.user.domain.MyVolunteerVO;
 import com.sbsj.dreamwing.user.dto.*;
@@ -181,13 +181,13 @@ public class UserServiceImpl implements UserService {
 
     }
 
-    public List<UserPointVO> getUserPointList(long userId) {
-        List<UserPointVO> userPointList = userMapper.getUserPointVOList(userId);
+    public List<MyPointVO> getUserPointList(long userId) {
+        List<MyPointVO> userPointList = userMapper.getUserPointVOList(userId);
         return userPointList;
     }
 
-    public List<UserSupportVO> getUserSupportList(long userId) {
-        List<UserSupportVO> userSupportList = userMapper.getUserSupportVOList(userId);
+    public List<MySupportVO> getUserSupportList(long userId) {
+        List<MySupportVO> userSupportList = userMapper.getUserSupportVOList(userId);
         return userSupportList;
     }
 
@@ -208,9 +208,9 @@ public class UserServiceImpl implements UserService {
 
         int totalSupportPoint = userMapper.selectTotalSupportPoint(userId);
 
-        List<UserSupportVO> supportDeatails = userMapper.getUserSupportVOList(userId);
+        List<MySupportVO> supportDeatails = userMapper.getUserSupportVOList(userId);
         List<MyVolunteerVO> volunteerDeatails = userMapper.getUserVolunteerVOList(userId) ;
-        List<UserPointVO> pointDetails = userMapper.getUserPointVOList(userId);
+        List<MyPointVO> pointDetails = userMapper.getUserPointVOList(userId);
 
         MyPageDTO myPageDTO = MyPageDTO.builder()
                 .name(userDTO.getName())

--- a/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sbsj/dreamwing/user/service/UserServiceImpl.java
@@ -1,14 +1,15 @@
 package com.sbsj.dreamwing.user.service;
 
+import com.sbsj.dreamwing.support.mapper.SupportMapper;
 import com.sbsj.dreamwing.user.domain.UserPointVO;
 import com.sbsj.dreamwing.user.domain.UserSupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
+import com.sbsj.dreamwing.user.domain.MyVolunteerVO;
 import com.sbsj.dreamwing.user.dto.*;
 import com.sbsj.dreamwing.user.mapper.UserMapper;
 import com.sbsj.dreamwing.util.JwtTokenProvider;
 import com.sbsj.dreamwing.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -29,13 +30,14 @@ import java.util.concurrent.TimeUnit;
  * <pre>
  * 수정일        		수정자       				    수정내용
  * ----------  ----------------    ---------------------------------
- *  2024.07.28     	정은찬        		       최초 생성 및 회원가입 기능
- *  2024.07.29      정은찬                      로그인 기능 추가
+ *  2024.07.28     	정은찬        		        최초 생성 및 회원가입 기능
+ *  2024.07.29      정은찬                       로그인 기능
  *  2024.07.31      정은찬                      회원탈퇴 기능 및 회원 정보 가져오기 기능 추가
  *  2024.07.31      정은찬                      회원 정보 업데이트 기능 및 로그아웃 기능 추가
  *  2024.07.31      정은찬                      포인트 내역 조회 기능 및 후원 내역 조회 기능 추가
  *  2024.07.31      정은찬                      회원가입 및 회원 정보 업데이트 프로필 이미지 S3 업로드 기능 추가
  *  2024.08.02      정은찬                      로그인 아이디 존재 여부 확인 기능 추가
+ *  2024.08.03      정은찬                      마이페이지 사용자 정보 조회 기능 추가
  * </pre>
  */
 @Service
@@ -47,6 +49,8 @@ public class UserServiceImpl implements UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, String> redisTemplate;
     private final S3Uploader s3Uploader;
+
+    private final SupportMapper supportMapper;
 
     @Transactional
     public String signUp(SignUpRequestDTO signUpRequestDTO) {
@@ -196,5 +200,26 @@ public class UserServiceImpl implements UserService {
         else {
             return false;
         }
+    }
+
+    public MyPageDTO getMyPageInfo(long userId) {
+        UserDTO userDTO = userMapper.selectUserByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("잘못된 아이디입니다"));
+
+        int totalSupportPoint = userMapper.selectTotalSupportPoint(userId);
+
+        List<UserSupportVO> supportDeatails = userMapper.getUserSupportVOList(userId);
+        List<MyVolunteerVO> volunteerDeatails = userMapper.getUserVolunteerVOList(userId) ;
+        List<UserPointVO> pointDetails = userMapper.getUserPointVOList(userId);
+
+        MyPageDTO myPageDTO = MyPageDTO.builder()
+                .name(userDTO.getName())
+                .phone(userDTO.getPhone())
+                .profileImageUrl(userDTO.getProfileImageUrl())
+                .totalPoint(userDTO.getTotalPoint())
+                .totalSupportPoint(totalSupportPoint)
+                .build();
+
+        return myPageDTO;
     }
 }

--- a/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
@@ -87,7 +87,7 @@
         WHERE USER_ID = #{userId}
     </update>
 
-    <select id="getUserPointVOList" resultType="UserPointVO">
+    <select id="getUserPointVOList" resultType="MyPointVO">
         SELECT ACTIVITY_TITLE,
                POINT,
                TO_CHAR(CREATED_DATE AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS CREATED_DATE
@@ -95,7 +95,7 @@
         WHERE USER_ID = #{userId}
     </select>
 
-    <select id="getUserSupportVOList" resultType="UserSupportVO">
+    <select id="getUserSupportVOList" resultType="MySupportVO">
         SELECT S.TITLE,
                S_HIST.POINT,
                TO_CHAR(S_HIST.CREATED_DATE AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS') AS CREATED_DATE

--- a/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/sbsj/dreamwing/user/mapper/UserMapper.xml
@@ -102,4 +102,19 @@
         FROM SUPPORT S, SUPPORT_HISTORY S_HIST
         WHERE S.SUPPORT_ID = S_HIST.SUPPORT_ID AND S_HIST.USER_ID = #{userId}
     </select>
+
+    <select id="selectTotalSupportPoint">
+        SELECT SUM(POINT)        AS TOTAL_SUPPORT_POINT
+        FROM   SUPPORT_HISTORY
+        WHERE USER_ID = #{userId}
+    </select>
+
+    <select id="getUserVolunteerVOList" resultType="MyVolunteerVO">
+        SELECT V.TITLE, V.VOLUNTEER_END_DATE, U_V.VERIFIED
+        FROM VOLUNTEER V, USER_VOLUNTEER U_V
+        WHERE V.volunteer_id = U_V.volunteer_id
+              AND U_V.user_id = #{userId}
+              AND U_V.status = 1
+
+    </select>
 </mapper>

--- a/src/test/java/com/sbsj/dreamwing/user/mapper/UserMapperTests.java
+++ b/src/test/java/com/sbsj/dreamwing/user/mapper/UserMapperTests.java
@@ -1,11 +1,10 @@
 package com.sbsj.dreamwing.user.mapper;
 
-import com.sbsj.dreamwing.user.domain.UserPointVO;
-import com.sbsj.dreamwing.user.domain.UserSupportVO;
+import com.sbsj.dreamwing.user.domain.MyPointVO;
+import com.sbsj.dreamwing.user.domain.MySupportVO;
 import com.sbsj.dreamwing.user.domain.UserVO;
 
 import com.sbsj.dreamwing.user.dto.UserDTO;
-import com.sbsj.dreamwing.user.dto.UserUpdateDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -99,13 +98,13 @@ public class UserMapperTests {
 
     @Test
     public void getUserPointVOListTest() {
-        List<UserPointVO> userPointVOList = userMapper.getUserPointVOList(1);
+        List<MyPointVO> userPointVOList = userMapper.getUserPointVOList(1);
         log.info(userPointVOList.toString());
     }
 
     @Test
     public void getUserSupportVOListTest() {
-        List<UserSupportVO> userSupportVOList = userMapper.getUserSupportVOList(1);
+        List<MySupportVO> userSupportVOList = userMapper.getUserSupportVOList(1);
         log.info(userSupportVOList.toString());
     }
 }

--- a/src/test/java/com/sbsj/dreamwing/user/service/UserServiceTests.java
+++ b/src/test/java/com/sbsj/dreamwing/user/service/UserServiceTests.java
@@ -1,7 +1,7 @@
 package com.sbsj.dreamwing.user.service;
 
-import com.sbsj.dreamwing.user.domain.UserPointVO;
-import com.sbsj.dreamwing.user.domain.UserSupportVO;
+import com.sbsj.dreamwing.user.domain.MyPointVO;
+import com.sbsj.dreamwing.user.domain.MySupportVO;
 import com.sbsj.dreamwing.user.dto.*;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -93,13 +93,13 @@ public class UserServiceTests {
 
     @Test
     public void getPointListTest() {
-        List<UserPointVO> userPointList = userService.getUserPointList(8);
+        List<MyPointVO> userPointList = userService.getUserPointList(8);
         log.info(userPointList.toString());
     }
 
     @Test
     public void getSupportListTest() {
-        List<UserSupportVO> userSupportList = userService.getUserSupportList(1);
+        List<MySupportVO> userSupportList = userService.getUserSupportList(1);
         log.info(userSupportList.toString());
     }
 


### PR DESCRIPTION
# 💡 PR 요약
마이페이지 사용자 정보 조회 기능을 구현하는 작업

## ⭐️ 관련 이슈
- closes : #62 
- closes: #53 

## ⭐️ 작업한 내용
- 마이페이지 사용자 정보 조회 API 작성
- 사용자의 이름, 프로필사진 url, 보유포인트, 총 후원 포인트를 가져온다.
- 사용자 봉사 내역 리스트 가져온다.

## ⭐️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
